### PR TITLE
feat: specify timeout in seconds instead of minutes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -80,11 +80,11 @@ export interface AcquireOptions {
    */
   readonly requester: string;
   /**
-   * How many minutes to wait in case an environment is not immediately available.
+   * How many seconds to wait in case an environment is not immediately available.
    *
-   * @default 10
+   * @default 600
    */
-  readonly timeoutMinutes?: number;
+  readonly timeoutSeconds?: number;
 }
 
 /**
@@ -114,9 +114,9 @@ export class AtmosphereClient {
    */
   public async acquire(options: AcquireOptions): Promise<Allocation> {
 
-    const timeoutMinutes = options.timeoutMinutes ?? 10;
+    const timeoutSeconds = options.timeoutSeconds ?? 600;
     const startTime = Date.now();
-    const timeoutMs = 60 * timeoutMinutes * 1000;
+    const timeoutMs = timeoutSeconds * 1000;
 
     let retryDelay = 1000; // start with 1 second
     const maxRetryDelay = 60000; // max 1 minute
@@ -137,7 +137,7 @@ export class AtmosphereClient {
 
           const elapsed = Date.now() - startTime;
           if (elapsed >= timeoutMs) {
-            throw new Error(`Failed to acquire environment within ${timeoutMinutes} minutes`);
+            throw new Error(`Failed to acquire environment within ${timeoutSeconds} seconds`);
           }
 
           this.log(`Acquire | Retrying due to: ${error.message}`);

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -97,7 +97,7 @@ describe('AtmosphereClient', () => {
       fetchMock.mockResponse(JSON.stringify({ message: 'No available environments' }), { status: 423, statusText: 'Locked' });
 
       const start = Date.now();
-      await expect(client.acquire({ pool: 'pool', requester: 'user' })).rejects.toThrow('Failed to acquire environment within 10 minutes');
+      await expect(client.acquire({ pool: 'pool', requester: 'user' })).rejects.toThrow('Failed to acquire environment within 600 seconds');
       const end = Date.now();
 
       expect(end - start).toBeLessThanOrEqual(11 * 60 * 1000);
@@ -110,7 +110,7 @@ describe('AtmosphereClient', () => {
 
       fetchMock.mockResponse(JSON.stringify({ message: 'No available environments' }), { status: 423, statusText: 'Locked' });
 
-      await expect(client.acquire({ pool: 'pool', requester: 'user' })).rejects.toThrow('Failed to acquire environment within 10 minutes');
+      await expect(client.acquire({ pool: 'pool', requester: 'user' })).rejects.toThrow('Failed to acquire environment within 600 seconds');
 
       expect(setTimeout).toHaveBeenNthCalledWith(14, expect.any(Function), 60 * 1000);
       expect(setTimeout).toHaveBeenNthCalledWith(15, expect.any(Function), 60 * 1000);
@@ -124,7 +124,7 @@ describe('AtmosphereClient', () => {
       fetchMock.mockResponse(JSON.stringify({ message: 'No available environments' }), { status: 423, statusText: 'Locked' });
 
       const start = Date.now();
-      await expect(client.acquire({ timeoutMinutes: 20, pool: 'pool', requester: 'user' })).rejects.toThrow('Failed to acquire environment within 20 minutes');
+      await expect(client.acquire({ timeoutSeconds: 1200, pool: 'pool', requester: 'user' })).rejects.toThrow('Failed to acquire environment within 1200 seconds');
       const end = Date.now();
 
       expect(end - start).toBeLessThanOrEqual(21 * 60 * 1000);


### PR DESCRIPTION
I'd like us to start using this client in the integration tests of the service itself, where we need to be able to specify short timeouts for testing purposes. 