### PR TITLE
feat: re-throw 423 errors

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,7 @@ import { AwsClient } from 'aws4fetch';
 /**
  * Error coming from the service.
  */
-class ServiceError extends Error {
+export class ServiceError extends Error {
   constructor(public readonly statusCode: number, message: string, statusText?: string) {
     super(`${statusCode} ${statusText ? `(${statusText})` : ''}: ${message}`);
   }
@@ -137,7 +137,7 @@ export class AtmosphereClient {
 
           const elapsed = Date.now() - startTime;
           if (elapsed >= timeoutMs) {
-            throw new Error(`Failed to acquire environment within ${timeoutSeconds} seconds`);
+            throw error;
           }
 
           this.log(`Acquire | Retrying due to: ${error.message}`);

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -97,7 +97,7 @@ describe('AtmosphereClient', () => {
       fetchMock.mockResponse(JSON.stringify({ message: 'No available environments' }), { status: 423, statusText: 'Locked' });
 
       const start = Date.now();
-      await expect(client.acquire({ pool: 'pool', requester: 'user' })).rejects.toThrow('Failed to acquire environment within 600 seconds');
+      await expect(client.acquire({ pool: 'pool', requester: 'user' })).rejects.toThrow('423 (Locked): No available environments');
       const end = Date.now();
 
       expect(end - start).toBeLessThanOrEqual(11 * 60 * 1000);
@@ -110,7 +110,7 @@ describe('AtmosphereClient', () => {
 
       fetchMock.mockResponse(JSON.stringify({ message: 'No available environments' }), { status: 423, statusText: 'Locked' });
 
-      await expect(client.acquire({ pool: 'pool', requester: 'user' })).rejects.toThrow('Failed to acquire environment within 600 seconds');
+      await expect(client.acquire({ pool: 'pool', requester: 'user' })).rejects.toThrow('423 (Locked): No available environments');
 
       expect(setTimeout).toHaveBeenNthCalledWith(14, expect.any(Function), 60 * 1000);
       expect(setTimeout).toHaveBeenNthCalledWith(15, expect.any(Function), 60 * 1000);
@@ -124,7 +124,7 @@ describe('AtmosphereClient', () => {
       fetchMock.mockResponse(JSON.stringify({ message: 'No available environments' }), { status: 423, statusText: 'Locked' });
 
       const start = Date.now();
-      await expect(client.acquire({ timeoutSeconds: 1200, pool: 'pool', requester: 'user' })).rejects.toThrow('Failed to acquire environment within 1200 seconds');
+      await expect(client.acquire({ timeoutSeconds: 1200, pool: 'pool', requester: 'user' })).rejects.toThrow('423 (Locked): No available environments');
       const end = Date.now();
 
       expect(end - start).toBeLessThanOrEqual(21 * 60 * 1000);


### PR DESCRIPTION
Currently we are swallowing 423 errors and rethrowing a generic `Error`, which is not great for integ testing.