### PR TITLE
fix: sig4v doesn't work when providing a custom domain name

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -171,6 +171,7 @@ export class AtmosphereClient {
         accessKeyId: creds.accessKeyId,
         secretAccessKey: creds.secretAccessKey,
         sessionToken: creds.sessionToken,
+        service: 'execute-api',
       });
     }
     return this._aws;


### PR DESCRIPTION
Because the service cannot be derived from a URL that points to a custom domain, so it must be set explicitly